### PR TITLE
Fix outline button hover contrast

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background text-foreground hover:bg-muted",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",


### PR DESCRIPTION
## Summary
- update the outline button variant to keep text readable on hover by using a muted background instead of the accent color

## Testing
- npm run lint *(fails: existing lint errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cec3c35c14833388e2ebf87c98d3b2