### PR TITLE
Fix MSAL relogin and SharePoint cache handling

### DIFF
--- a/src/contexts/SharePointContext.tsx
+++ b/src/contexts/SharePointContext.tsx
@@ -172,19 +172,43 @@ export const SharePointProvider: React.FC<SharePointProviderProps> = ({ children
       const cachedWorkOrdersData = localStorage.getItem('sharepoint_cached_workorders');
       
       if (cachedClientsData) {
-        const clients = JSON.parse(cachedClientsData);
-        if (clients.length > 0) {
-          setCachedClients(clients);
-          console.log('📦 Context loaded cached clients:', clients.length);
+        try {
+          const clients = JSON.parse(cachedClientsData);
+          if (Array.isArray(clients)) {
+            setCachedClients(clients);
+            if (clients.length > 0) {
+              console.log('📦 Context loaded cached clients:', clients.length);
+            }
+          } else {
+            console.warn('Cached clients data is not an array');
+            setCachedClients([]);
+          }
+        } catch (parseError) {
+          console.error('Error parsing cached clients data:', parseError);
+          setCachedClients([]);
         }
+      } else {
+        setCachedClients([]);
       }
-      
+
       if (cachedWorkOrdersData) {
-        const workOrders = JSON.parse(cachedWorkOrdersData);
-        if (workOrders.length > 0) {
-          setCachedWorkOrders(workOrders);
-          console.log('📦 Context loaded cached work orders:', workOrders.length);
+        try {
+          const workOrders = JSON.parse(cachedWorkOrdersData);
+          if (Array.isArray(workOrders)) {
+            setCachedWorkOrders(workOrders);
+            if (workOrders.length > 0) {
+              console.log('📦 Context loaded cached work orders:', workOrders.length);
+            }
+          } else {
+            console.warn('Cached work orders data is not an array');
+            setCachedWorkOrders([]);
+          }
+        } catch (parseError) {
+          console.error('Error parsing cached work orders data:', parseError);
+          setCachedWorkOrders([]);
         }
+      } else {
+        setCachedWorkOrders([]);
       }
     } catch (error) {
       console.error('Error loading cached data:', error);
@@ -336,8 +360,10 @@ export const SharePointProvider: React.FC<SharePointProviderProps> = ({ children
     localStorage.removeItem('sharepoint_connection_time');
     localStorage.removeItem('sharepoint_cached_clients');
     localStorage.removeItem('sharepoint_cached_workorders');
+    localStorage.removeItem('sharepoint_cached_tubing');
     localStorage.removeItem('sharepoint_clients_timestamp');
     localStorage.removeItem('sharepoint_workorders_timestamp');
+    localStorage.removeItem('sharepoint_cached_tubing_timestamp');
     localStorage.removeItem('sharepoint_last_refresh');
     
     console.log('SharePoint disconnected and cache cleared (MSAL tokens preserved)');

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,5 @@
-import { Header } from "@/components/layout/Header";
 import { MainDashboard } from "@/components/dashboard/MainDashboard";
 
 export default function Index() {
-  return (
-    <div className="min-h-screen bg-gray-50">
-      <Header />
-      <MainDashboard />
-    </div>
-  );
+  return <MainDashboard />;
 }

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -90,7 +90,13 @@ class AuthService {
       await this.msalInstance.initialize();
       
       // Force login with account selection
-      return await this.login();
+      const silentSuccess = await this.login();
+      if (silentSuccess) {
+        return true;
+      }
+
+      // If there are no active accounts after cache clear, force popup login
+      return await this.forcePopupLogin();
     } catch (error) {
       console.error("Failed to clear cache and relogin:", error);
       return false;


### PR DESCRIPTION
## Summary
- remove duplicate header rendering on the main page by delegating layout responsibility to MainDashboard
- force an interactive MSAL login when the cache is cleared so users are prompted to sign in again
- refresh SharePoint viewer state when cached datasets become empty and clear tubing cache on disconnect

## Testing
- npm run lint *(fails: existing lint violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cec71eba2c8333834bd4d81c20c0f0