### PR TITLE
Fix tubing insertion order and update tubing arrival fields

### DIFF
--- a/src/pages/TubingForm.tsx
+++ b/src/pages/TubingForm.tsx
@@ -24,8 +24,7 @@ export default function TubingForm() {
     pipe_to: "",
     rack: "",
     status: "Arrived",
-    start_date: "",
-    end_date: ""
+    arrival_date: ""
   });
 
   const [availableClients, setAvailableClients] = useState<string[]>([]);
@@ -343,9 +342,8 @@ export default function TubingForm() {
       pipe_from: formData.pipe_from,
       pipe_to: formData.pipe_to,
       rack: formData.rack,
-      status: formData.status,
-      start_date: formData.start_date,
-      end_date: formData.end_date
+      status: 'Arrived',
+      arrival_date: formData.arrival_date
     });
     
     try {
@@ -359,9 +357,8 @@ export default function TubingForm() {
         pipe_from: formData.pipe_from,
         pipe_to: formData.pipe_to,
         rack: formData.rack,
-        status: formData.status,
-        start_date: formData.start_date,
-        end_date: formData.end_date
+        status: 'Arrived',
+        arrival_date: formData.arrival_date
       });
       
       if (success) {
@@ -391,8 +388,7 @@ export default function TubingForm() {
           pipe_to: "",
           rack: "",
           status: "Arrived",
-          start_date: "",
-          end_date: ""
+          arrival_date: ""
         });
       } else {
         toast({
@@ -608,43 +604,23 @@ export default function TubingForm() {
 
                 <div>
                   <Label htmlFor="status">Status</Label>
-                  <Select
+                  <Input
+                    id="status"
                     value={formData.status}
-                    onValueChange={(value) => handleInputChange("status", value)}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="Arrived">Arrived</SelectItem>
-                      <SelectItem value="Ins. Done">Ins. Done</SelectItem>
-                      <SelectItem value="Completed">Completed</SelectItem>
-                    </SelectContent>
-                  </Select>
+                    readOnly
+                    className="bg-gray-100 text-gray-600"
+                  />
                 </div>
               </div>
 
-              {/* Dates */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="start_date">Start Date</Label>
-                  <Input
-                    id="start_date"
-                    type="date"
-                    value={formData.start_date}
-                    onChange={(e) => handleInputChange("start_date", e.target.value)}
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="end_date">End Date</Label>
-                  <Input
-                    id="end_date"
-                    type="date"
-                    value={formData.end_date}
-                    onChange={(e) => handleInputChange("end_date", e.target.value)}
-                  />
-                </div>
+              <div>
+                <Label htmlFor="arrival_date">Arrival Date</Label>
+                <Input
+                  id="arrival_date"
+                  type="date"
+                  value={formData.arrival_date}
+                  onChange={(e) => handleInputChange("arrival_date", e.target.value)}
+                />
               </div>
 
               <div className="flex justify-end space-x-4 pt-6 border-t-2 border-gray-100">

--- a/src/services/sharePointService.ts
+++ b/src/services/sharePointService.ts
@@ -584,11 +584,18 @@ export class SharePointService {
     }
 
     const headers = currentData[0];
-    const clientIndex = headers.findIndex((header: string) => 
-      header && header.toLowerCase().includes('client')
+    const normalize = (value: any) =>
+      value === null || value === undefined
+        ? ''
+        : String(value).trim().toLowerCase();
+    const targetClient = normalize(client);
+    const targetWo = normalize(woNo);
+
+    const clientIndex = headers.findIndex((header: string) =>
+      header && String(header).toLowerCase().includes('client')
     );
-    const woIndex = headers.findIndex((header: string) => 
-      header && header.toLowerCase().includes('wo')
+    const woIndex = headers.findIndex((header: string) =>
+      header && String(header).toLowerCase().includes('wo')
     );
 
     if (clientIndex === -1 || woIndex === -1) {
@@ -599,7 +606,10 @@ export class SharePointService {
     // Найти последнюю строку с этим клиентом и WO
     let lastClientWoRow = -1;
     for (let i = currentData.length - 1; i >= 1; i--) { // Начинаем с конца, пропускаем заголовки
-      if (currentData[i][clientIndex] === client && currentData[i][woIndex] === woNo) {
+      const rowClient = normalize(currentData[i][clientIndex]);
+      const rowWo = normalize(currentData[i][woIndex]);
+      if (!rowClient && !rowWo) continue; // пропускаем полностью пустые строки
+      if (rowClient === targetClient && rowWo === targetWo) {
         lastClientWoRow = i;
         break;
       }
@@ -610,7 +620,9 @@ export class SharePointService {
       // Найти последнюю запись этого клиента (любого WO)
       let lastClientRow = -1;
       for (let i = currentData.length - 1; i >= 1; i--) {
-        if (currentData[i][clientIndex] === client) {
+        const rowClient = normalize(currentData[i][clientIndex]);
+        if (!rowClient) continue;
+        if (rowClient === targetClient) {
           lastClientRow = i;
           break;
         }
@@ -1110,8 +1122,7 @@ export class SharePointService {
         if (headerLower.includes('pipe_to') || headerLower.includes('to')) return data.pipe_to;
         if (headerLower.includes('rack')) return data.rack || '';
         if (headerLower.includes('status')) return data.status || 'Arrived';
-        if (headerLower.includes('start_date')) return data.start_date;
-        if (headerLower.includes('end_date')) return data.end_date;
+        if (headerLower.includes('arrival')) return data.arrival_date;
         return ''; // Пустое значение для неизвестных колонок
       });
 


### PR DESCRIPTION
## Summary
- normalize client and work order comparisons when calculating tubing insert positions so new batches are added under the correct work order
- send the tubing arrival date column to SharePoint while defaulting the status to Arrived
- update the tubing form to collect an arrival date, lock the status input, and remove the start/end date fields

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d106cb3aac8333a650be235c4ac5ba