### PR TITLE
Stop writing inspection scrap quantities to SharePoint

### DIFF
--- a/src/pages/InspectionData.tsx
+++ b/src/pages/InspectionData.tsx
@@ -395,18 +395,6 @@ export default function InspectionData() {
     return { rattling: r, external: ext, hydro: hyd, mpi: mp, drift: dr, emi: em, marking: mark };
   }, [initialQty, scrapInputs]);
 
-  const scrapNumbers = useMemo(() => {
-    const parseStrict = (v: string) => (v === "" ? null : Number(v));
-    return {
-      rattling: parseStrict(scrapInputs.rattling),
-      external: parseStrict(scrapInputs.external),
-      jetting: parseStrict(scrapInputs.jetting),
-      mpi: parseStrict(scrapInputs.mpi),
-      drift: parseStrict(scrapInputs.drift),
-      emi: parseStrict(scrapInputs.emi)
-    } as Record<ScrapKey, number | null>;
-  }, [scrapInputs]);
-
   const totalScrap = useMemo(() => {
     return (Object.values(scrapInputs) as string[]).reduce((sum, v) => {
       const n = v === "" ? 0 : Number(v);
@@ -500,12 +488,6 @@ export default function InspectionData() {
       drift_qty: stageNumbers.drift,
       emi_qty: stageNumbers.emi,
       marking_qty: stageNumbers.marking,
-      rattling_scrap_qty: scrapNumbers.rattling ?? 0,
-      external_scrap_qty: scrapNumbers.external ?? 0,
-      jetting_scrap_qty: scrapNumbers.jetting ?? 0,
-      mpi_scrap_qty: scrapNumbers.mpi ?? 0,
-      drift_scrap_qty: scrapNumbers.drift ?? 0,
-      emi_scrap_qty: scrapNumbers.emi ?? 0,
       status: "Inspection Done"
     });
     setIsSaving(false);

--- a/src/services/sharePointService.ts
+++ b/src/services/sharePointService.ts
@@ -1171,12 +1171,6 @@ export class SharePointService {
     drift_qty?: number;
     emi_qty?: number;
     marking_qty?: number;
-    rattling_scrap_qty?: number;
-    external_scrap_qty?: number;
-    jetting_scrap_qty?: number;
-    mpi_scrap_qty?: number;
-    drift_scrap_qty?: number;
-    emi_scrap_qty?: number;
     status?: string;
   }): Promise<boolean> {
     try {
@@ -1295,31 +1289,6 @@ export class SharePointService {
         const c = canonical ?? header;
         return header.includes('marking_qty') || c.includes('marking_qty');
       }, data.marking_qty ?? '');
-
-      applyValue((header, canonical) => {
-        const c = canonical ?? header;
-        return header.includes('rattling_scrap_qty') || c.includes('rattling_scrap_qty');
-      }, data.rattling_scrap_qty ?? '');
-      applyValue((header, canonical) => {
-        const c = canonical ?? header;
-        return header.includes('external_scrap_qty') || c.includes('external_scrap_qty');
-      }, data.external_scrap_qty ?? '');
-      applyValue((header, canonical) => {
-        const c = canonical ?? header;
-        return header.includes('jetting_scrap_qty') || c.includes('jetting_scrap_qty') || c.includes('hydro_scrap_qty');
-      }, data.jetting_scrap_qty ?? '');
-      applyValue((header, canonical) => {
-        const c = canonical ?? header;
-        return header.includes('mpi_scrap_qty') || c.includes('mpi_scrap_qty');
-      }, data.mpi_scrap_qty ?? '');
-      applyValue((header, canonical) => {
-        const c = canonical ?? header;
-        return header.includes('drift_scrap_qty') || c.includes('drift_scrap_qty');
-      }, data.drift_scrap_qty ?? '');
-      applyValue((header, canonical) => {
-        const c = canonical ?? header;
-        return header.includes('emi_scrap_qty') || c.includes('emi_scrap_qty');
-      }, data.emi_scrap_qty ?? '');
 
       const startColLetters = this.indexToColLetters(meta.startCol);
       const endColLetters = this.indexToColLetters(meta.startCol + usedWidth - 1);


### PR DESCRIPTION
## Summary
- stop passing per-stage scrap quantity values when saving inspection data
- remove SharePoint updates that overwrote scrap quantity columns so Excel formulas remain intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b7e22e2c833380f2c3193347f1eb