### PR TITLE
Improve edit workflows with cancel and unsaved warnings

### DIFF
--- a/src/hooks/use-unsaved-changes.ts
+++ b/src/hooks/use-unsaved-changes.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { useBeforeUnload, useBlocker } from "react-router-dom";
+
+/**
+ * Shows a confirmation dialog when the user attempts to close the tab or
+ * navigate away with pending form changes. The hook integrates with the
+ * browser's beforeunload event and the client-side router navigation.
+ */
+export function useUnsavedChangesWarning(when: boolean, message = "You have unsaved changes. They will be lost if you leave this page.") {
+  useBeforeUnload(
+    event => {
+      if (!when) {
+        return;
+      }
+
+      event.preventDefault();
+      event.returnValue = message;
+      return message;
+    },
+    { capture: true }
+  );
+
+  const blocker = useBlocker(when);
+
+  useEffect(() => {
+    if (blocker.state !== "blocked") {
+      return;
+    }
+
+    const shouldLeave = window.confirm(message);
+    if (shouldLeave) {
+      blocker.proceed();
+    } else {
+      blocker.reset();
+    }
+  }, [blocker, message]);
+}
+


### PR DESCRIPTION
## Summary
- add a reusable unsaved-changes hook and use it across the load out, inspection, and tubing registry edit screens
- preserve the selected batch when returning to Edit Records, add cancel/reset flows, and lighten the supporting cards for a cleaner presentation
- align the selectors and inputs on the Batch Selection card and offer a quick cancel option to clear the form

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d48480a5a4833396c865711065cf5c