### PR TITLE
Refine edit workflows and safeguard tubing formulas

### DIFF
--- a/src/pages/EditRecords.tsx
+++ b/src/pages/EditRecords.tsx
@@ -109,7 +109,7 @@ export default function EditRecords() {
 
     return STATUS_OPTIONS.filter(option => {
       const optionRank = getStatusRank(option.value);
-      return optionRank !== -1 && optionRank <= currentRank;
+      return optionRank !== -1 && optionRank < currentRank;
     });
   }, [selectedRecord]);
 

--- a/src/services/sharePointService.ts
+++ b/src/services/sharePointService.ts
@@ -1748,16 +1748,6 @@ export class SharePointService {
         data.scrap ?? ''
       );
 
-      applyValue((header, canonical) => canonical.includes('rattling_scrap'), data.rattling_scrap_qty ?? '');
-      applyValue((header, canonical) => canonical.includes('external_scrap'), data.external_scrap_qty ?? '');
-      applyValue(
-        (header, canonical) => canonical.includes('hydro_scrap') || canonical.includes('jetting_scrap'),
-        data.jetting_scrap_qty ?? ''
-      );
-      applyValue((header, canonical) => canonical.includes('mpi_scrap'), data.mpi_scrap_qty ?? '');
-      applyValue((header, canonical) => canonical.includes('drift_scrap'), data.drift_scrap_qty ?? '');
-      applyValue((header, canonical) => canonical.includes('emi_scrap'), data.emi_scrap_qty ?? '');
-
       applyValue(
         (header, canonical) => {
           const c = canonical ?? header;


### PR DESCRIPTION
## Summary
- limit Edit Records status changes to earlier stages and prevent accidental refresh resets during editing
- add cancel actions and discard confirmations to each edit screen while skipping saves when no changes are made
- leave tubing scrap formulas untouched and improve load out AVR input behaviour

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ec0c81c88333bdbddf08f628bedf